### PR TITLE
up

### DIFF
--- a/python-ffi/Data/Function/Uncurried.py
+++ b/python-ffi/Data/Function/Uncurried.py
@@ -1,7 +1,17 @@
 ## Function Creators
 def mkFn0(fn):
     def func():
-        return fn()
+        # Specially, `{}` in JavaScript
+        # is translated to `()` in Python,
+        # if `{}` means Unit here.
+        # The reason why we don't use
+        # `{}` in Python to stand for
+        # Unit is, `()` is a constant
+        # but `{}` creates an empty
+        # in execution time.
+        # `fn` does accept Unit,
+        # see https://github.com/purescript/purescript-functions/blob/master/src/Data/Function/Uncurried.purs#L39
+        return fn(())
     return func
 
 def mkFn2(fn):


### PR DESCRIPTION
Specifically, some uses of `{}` in JavaScript is translated to `()` in Python, if `{}` means `Unit` here.

The reason why we don't use `{}` in Python to stand for Unit is, `()` is a constant, but `{}` creates an empty dict in execution time.

This is a benchmark via timeit lib and IPython:

```python
In [1]: %timeit {}
32.6 ns ± 0.989 ns per loop (mean ± std. dev. of 7 runs, 10000000 loops each)

In [2]: %timeit ()
8.35 ns ± 0.329 ns per loop (mean ± std. dev. of 7 runs, 100000000 loops each)
```

At here: https://github.com/purescript-python/purescript-functions.py/blob/8ffea0602f62333371d43d36d40fc93e5462344b/python-ffi/Data/Function/Uncurried.py#L2-L6

<details>
<summary>Compare to the JavaScript code</summary>

```javascript
exports.mkFn0 = function (fn) {
  return function () {
    return fn({});
  };
};
```

</details>

`fn` does accept an Unit, see [this link](https://github.com/purescript/purescript-functions/blob/master/src/Data/Function/Uncurried.purs#L39):
```purescript
foreign import mkFn0 :: forall a. (Unit -> a) -> Fn0 a
```

Besides, you might why we need to pass an argument